### PR TITLE
Resolve errors when trying to use distilbert in an encoder/decoder model

### DIFF
--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -734,6 +734,7 @@ class DistilBertModel(DistilBertPreTrainedModel):
         encoder_hidden_states=None,
         encoder_attention_mask=None,
         past_key_values=None,
+        use_cache=None,
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
@@ -834,6 +835,7 @@ class DistilBertForCausalLM(DistilBertPreTrainedModel):
         encoder_hidden_states=None,
         encoder_attention_mask=None,
         past_key_values=None,
+        use_cache=None,
         inputs_embeds=None,
         labels=None,
         output_attentions=None,
@@ -885,6 +887,7 @@ class DistilBertForCausalLM(DistilBertPreTrainedModel):
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
             past_key_values=past_key_values,
+            use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
@@ -914,14 +917,18 @@ class DistilBertForCausalLM(DistilBertPreTrainedModel):
             cross_attentions=outputs.cross_attentions,
         )
 
-    def prepare_inputs_for_generation(self, input_ids, attention_mask=None, **model_kwargs):
+    def prepare_inputs_for_generation(self, input_ids, past=None, attention_mask=None, **model_kwargs):
         input_shape = input_ids.shape
 
         # if model is used as a decoder in encoder-decoder model, the decoder attention mask is created on the fly
         if attention_mask is None:
             attention_mask = input_ids.new_ones(input_shape)
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask}
+        # cut decoder_input_ids if past is used
+        if past is not None:
+            input_ids = input_ids[:, -1:]
+
+        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past}
 
 
 @add_start_docstrings(


### PR DESCRIPTION
Hey, I'm trying to use your code to use distilbert as encoder/decoder, but ran into some errors. These changes fix the errors, however it seems like it's now not properly identifying the masks. I was hoping you could offer some insights, as it seems like a task you're trying to enable with your implementation.

I have this simple bert2bert pipeline to do summarization: https://colab.research.google.com/drive/1uFttq_3cNzOlOYSQLEGc9Vcd_t_15l3g?usp=sharing, that I was hoping to transform into a 'distilbert2distilbert' pipeline: https://colab.research.google.com/drive/1UpvyFv_X86xL28mxK8Nt9TN3oymeRYEc#scrollTo=9a88f91a&uniqifier=1.

However, as you can see under the **training** cell in the second colab, this throws the following error: `TypeError: forward() got an unexpected keyword argument 'use_cache'`. The first three edits in this PR about the `use_cache` solve this error, and the other edit of this PR solves the next exception that you'll run into. Unfortunately now the *validation loss* is `NaN` and nothing particular useful is generated...
![WhatsApp Image 2022-04-05 at 8 04 29 PM](https://user-images.githubusercontent.com/15660621/161849811-482da6d2-4ab2-4485-aad6-5f013f131329.jpeg)
![WhatsApp Image 2022-04-05 at 9 20 24 PM](https://user-images.githubusercontent.com/15660621/161848878-4cb0964f-13e3-447d-b22a-523782191965.jpeg)

Here is a Colab where I switched out your repo for mine: https://colab.research.google.com/drive/1fxf8k7nJZ6jwEb56HD6NMw81z3uZFvfd?usp=sharing

Do you have any idea what might be going on? I hope I'm not doing anything stupid and this is actually a useful insight for you!